### PR TITLE
util.is_node_healthy should check for an error condition

### DIFF
--- a/shaman/tests/test_util.py
+++ b/shaman/tests/test_util.py
@@ -10,14 +10,14 @@ class TestIsNodeHealthy(object):
 
     @patch("shaman.util.requests.get")
     def test_node_is_healthy(self, m_get, session):
-        m_get.return_value.status_code = 200
+        m_get.return_value.ok = True
         node = Node("chacra.ceph.com")
         session.commit()
         assert util.is_node_healthy(node)
 
     @patch("shaman.util.requests.get")
     def test_last_check_is_updated(self, m_get, session):
-        m_get.return_value.status_code = 200
+        m_get.return_value.ok = True
         node = Node("chacra.ceph.com")
         last_check = datetime.datetime.now()
         node.last_check = datetime.datetime.now()
@@ -28,7 +28,7 @@ class TestIsNodeHealthy(object):
 
     @patch("shaman.util.requests.get")
     def test_down_count_is_cleared_when_healthy(self, m_get, session):
-        m_get.return_value.status_code = 200
+        m_get.return_value.ok = True
         node = Node("chacra.ceph.com")
         node.down_count = 2
         session.commit()
@@ -38,14 +38,14 @@ class TestIsNodeHealthy(object):
 
     @patch("shaman.util.requests.get")
     def test_node_is_not_healthy(self, m_get, session):
-        m_get.return_value.status_code = 500
+        m_get.return_value.ok = False
         node = Node("chacra.ceph.com")
         session.commit()
         assert not util.is_node_healthy(node)
 
     @patch("shaman.util.requests.get")
     def test_down_count_is_incremented(self, m_get, session):
-        m_get.return_value.status_code = 500
+        m_get.return_value.ok = False
         node = Node("chacra.ceph.com")
         session.commit()
         util.is_node_healthy(node)
@@ -54,7 +54,7 @@ class TestIsNodeHealthy(object):
 
     @patch("shaman.util.requests.get")
     def test_node_exceeds_down_count_limit(self, m_get, session):
-        m_get.return_value.status_code = 500
+        m_get.return_value.ok = False
         node = Node("chacra.ceph.com")
         node.down_count = 2
         session.commit()


### PR DESCRIPTION
Instead of checking to see if the return code == 200,
check to see if the response is "not ok" instead.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>