### PR TITLE
implements a /_health/ endpoint

### DIFF
--- a/config/dev.py
+++ b/config/dev.py
@@ -73,3 +73,6 @@ api_key = 'secret'
 # check can fail before being marked down and taken
 # out of the pool.
 health_check_retries = 3
+
+# if this file exists the check at /_health/ will fail
+fail_check_trigger_path = "/tmp/fail_check"

--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -58,6 +58,9 @@ logging = {
     }
 }
 
+# if this file exists the check at /_health/ will fail
+fail_check_trigger_path = "/tmp/fail_check"
+
 # production Basic HTTP Auth credentials are imported from prod_api_creds.py
 
 # production database configurations are imported from prod_db.py

--- a/shaman/checks.py
+++ b/shaman/checks.py
@@ -55,4 +55,4 @@ def is_healthy():
         except Exception:
             logger.exception('system is unhealthy')
             return False
-        return True
+    return True

--- a/shaman/checks.py
+++ b/shaman/checks.py
@@ -1,0 +1,43 @@
+from shaman import models
+from sqlalchemy.exc import OperationalError
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+class SystemCheckError(Exception):
+
+    def __init__(self, message):
+        self.message = message
+
+
+def database_connection():
+    """
+    A very simple connection that should succeed if there is a good/correct
+    database connection.
+    """
+    try:
+        models.Project.get(1)
+    except OperationalError as exc:
+        raise SystemCheckError(
+            "Could not connect or retrieve information from the database: %s" % exc.message)
+
+
+system_checks = (
+    database_connection
+)
+
+
+def is_healthy():
+    """
+    Perform all the registered system checks and detect if anything fails so
+    that the system can send a callback indicating an OK status
+    """
+    for check in system_checks:
+        try:
+            check()
+        except Exception:
+            logger.exception('system is unhealthy')
+            return False
+        return True

--- a/shaman/checks.py
+++ b/shaman/checks.py
@@ -1,6 +1,9 @@
 from shaman import models
 from sqlalchemy.exc import OperationalError
 import logging
+import os
+
+from pecan import conf
 
 
 logger = logging.getLogger(__name__)
@@ -24,8 +27,20 @@ def database_connection():
             "Could not connect or retrieve information from the database: %s" % exc.message)
 
 
+def fail_health_check():
+    """
+    Checks for the existance of a file and if that file exists it fails
+    the check. This is used to manually take a node out of rotation for
+    maintenance.
+    """
+    check_file_path = getattr(conf, "fail_check_trigger_path", "/tmp/fail_check")
+    if os.path.exists(check_file_path):
+        raise SystemCheckError("%s was found, failing health check" % check_file_path)
+
+
 system_checks = (
-    database_connection
+    database_connection,
+    fail_health_check,
 )
 
 

--- a/shaman/controllers/health.py
+++ b/shaman/controllers/health.py
@@ -1,0 +1,11 @@
+from pecan import expose, abort
+
+from shaman import checks
+
+
+class HealthController(object):
+
+    @expose()
+    def index(self):
+        if not checks.is_healthy():
+            abort(500)

--- a/shaman/controllers/health.py
+++ b/shaman/controllers/health.py
@@ -5,7 +5,7 @@ from shaman import checks
 
 class HealthController(object):
 
-    @expose()
+    @expose(content_type="text/plain")
     def index(self):
         if not checks.is_healthy():
             abort(500)

--- a/shaman/controllers/root.py
+++ b/shaman/controllers/root.py
@@ -1,6 +1,6 @@
 from pecan import expose
 
-from shaman.controllers import repos, nodes
+from shaman.controllers import repos, nodes, health
 
 description = "shaman is the source of truth for the state of repositories on chacra nodes."
 
@@ -27,3 +27,4 @@ class RootController(object):
         )
 
     api = APIController()
+    _health = health.HealthController()

--- a/shaman/tests/config.py
+++ b/shaman/tests/config.py
@@ -14,6 +14,7 @@ app = {
     'modules': ['shaman'],
     'static_root': '%(confdir)s/public',
     'guess_content_type_from_ext': False,
+    'default_renderer': 'json',
     'hooks': [
         TransactionHook(
             models.start,

--- a/shaman/tests/config.py
+++ b/shaman/tests/config.py
@@ -86,3 +86,6 @@ api_key = 'secret'
 # check can fail before being marked down and taken
 # out of the pool.
 health_check_retries = 3
+
+# if this file exists the check at /_health/ will fail
+fail_check_trigger_path = "/tmp/fail_check"

--- a/shaman/tests/config.py
+++ b/shaman/tests/config.py
@@ -13,7 +13,6 @@ app = {
     'root': 'shaman.controllers.root.RootController',
     'modules': ['shaman'],
     'static_root': '%(confdir)s/public',
-    'default_renderer': 'json',
     'guess_content_type_from_ext': False,
     'hooks': [
         TransactionHook(

--- a/shaman/tests/controllers/test_health.py
+++ b/shaman/tests/controllers/test_health.py
@@ -1,0 +1,14 @@
+from shaman.controllers import health
+
+
+class TestHealthController(object):
+
+    def test_passes_health_check(self, session, monkeypatch):
+        monkeypatch.setattr(health.checks, "is_healthy", lambda: True)
+        result = session.app.get("/_health/")
+        assert result.status_int == 204
+
+    def test_fails_health_check(self, session, monkeypatch):
+        monkeypatch.setattr(health.checks, "is_healthy", lambda: False)
+        result = session.app.get("/_health/", expect_errors=True)
+        assert result.status_int == 500


### PR DESCRIPTION
This will be used for the load balancer. This endpoint verifies that we can read from the database as well as giving us a way to manually fail the health check if we need to remove the node from the pool for maintenance.