### PR TITLE
Letsencrypt support!

### DIFF
--- a/deploy/playbooks/examples/deploy_production.yml
+++ b/deploy/playbooks/examples/deploy_production.yml
@@ -1,0 +1,100 @@
+---
+
+- hosts: postgresql_master
+  user: ubuntu
+  roles:
+    - postgresql
+  vars:
+     app_name: "shaman"
+     use_ssl: true
+     ansible_ssh_port: 2222
+     development_server: false
+     fqdn: "1.shaman.ceph.com"
+     api_user: "admin"
+     api_key: "secret"
+     # postgres specific
+     postgresql_replication: true
+     postgresql_replication_master_ip: "{{ master_ip }}"
+     postgresql_cfg_listen_addresses: "localhost,127.0.0.1,{{ master_ip }}"
+     postgresql_cfg_wal_level: 'hot_standby'
+     postgresql_cfg_max_wal_senders: 3
+     postgresql_cfg_archive_mode: 'on'
+     postgresql_cfg_archive_command: 'test ! -f {{ postgresql_archive_dir_path }}/%f && cp %p {{ postgresql_archive_dir_path }}/%f'
+
+     postgresql_users:
+       - user: "{{ app_name }}"
+         connections:
+           - database: "{{ app_name }}"
+             type: local
+             auth: md5
+           - database: "{{ app_name }}"
+             type: host
+             address: "{{ standby_ip }}/32"
+             auth: md5
+           - database: "{{ app_name }}"
+             type: host
+             address: "{{ master_ip }}/32"
+             auth: md5
+
+     postgresql_replication_hosts:
+       - address: "{{ standby_ip }}"
+         auth: md5
+
+- hosts: postgresql_standby
+  user: ubuntu
+  roles:
+    - postgresql
+  vars:
+     postgresql_replication: true
+     app_name: "shaman"
+     use_ssl: true
+     ansible_ssh_port: 2222
+     development_server: false
+     fqdn: "2.shaman.ceph.com"
+     api_user: "admin"
+     api_key: "secret"
+     # postgres specific
+     postgresql_cfg_listen_addresses: "localhost,127.0.0.1,{{ standby_ip }}"
+     postgresql_replication_master_ip: "{{ master_ip }}"
+     postgresql_cfg_hot_standby: 'on'
+     postgresql_cfg_archive_command: 'test ! -f {{ postgresql_archive_dir_path }}/%f && cp %p {{ postgresql_archive_dir_path }}/%f'
+
+     postgresql_users:
+       - user: "{{ app_name }}"
+         connections:
+           - database: "{{ app_name }}"
+             type: local
+             auth: md5
+           - database: "{{ app_name }}"
+             type: host
+             address: "{{ master_ip }}/32"
+             auth: md5
+           - database: "{{ app_name }}"
+             type: host
+             address: "{{ standby_ip }}/32"
+             auth: md5
+
+     postgresql_replication_hosts:
+       - address: "{{ standby_ip }}"
+         auth: md5
+
+- hosts: app
+  user: ubuntu
+  roles:
+    - common
+  vars:
+     app_name: "shaman"
+     use_ssl: true
+     wsgi_file: wsgi.py
+     wsgi_callable: application
+     ansible_ssh_port: 2222
+     restart_app: true
+     branch: "master"
+     development_server: false
+     fqdn: "{{ inventory_hostname }}"
+     nginx_ssl_cert_path: "/etc/letsencrypt/live/{{ fqdn }}/fullchain.pem"
+     nginx_ssl_key_path: "/etc/letsencrypt/live/{{ fqdn }}/privkey.pem"
+     api_user: "admin"
+     api_key: "secret"
+  tags:
+    - deploy_app

--- a/deploy/playbooks/examples/deploy_vagrant.yml
+++ b/deploy/playbooks/examples/deploy_vagrant.yml
@@ -91,7 +91,9 @@
      restart_app: true
      branch: "master"
      development_server: true
-     fqdn: "localhost"
+     fqdn: "{{ inventory_hostname }}"
+     nginx_ssl_cert_path: "/etc/ssl/certs/{{ fqdn }}-bundled.crt"
+     nginx_ssl_key_path: "/etc/ssl/private/{{ fqdn }}.key"
      api_user: "admin"
      api_key: "secret"
   tags:

--- a/deploy/playbooks/examples/hosts
+++ b/deploy/playbooks/examples/hosts
@@ -1,6 +1,6 @@
 [app]
-1.node.a fqdn=1.node.a ssl_cert_path="files/ssl/dev/ssl.crt" ssl_key_path="files/ssl/dev/ssl.key"
-2.node.a fqdn=2.node.a ssl_cert_path="files/ssl/dev/ssl.crt" ssl_key_path="files/ssl/dev/ssl.key"
+1.node.a
+2.node.a
 
 [postgresql_master]
 1.node.a

--- a/deploy/playbooks/roles/common/defaults/main.yml
+++ b/deploy/playbooks/roles/common/defaults/main.yml
@@ -2,3 +2,6 @@
 app_home: /opt/{{ app_name }}
 app_use_ssl: yes
 postgresql_app_user_password: "{{ generated_app_user_password.stdout }}"
+ssl_support_email: "adeza@redhat.com"
+ssl_webroot_path: "/var/www/{{ fqdn }}"
+letsencrypt_command: "letsencrypt certonly --webroot -w {{ ssl_webroot_path }} -d {{ fqdn }} --email {{ ssl_support_email }} --agree-tos --renew-by-default"

--- a/deploy/playbooks/roles/common/tasks/letsencrypt.yml
+++ b/deploy/playbooks/roles/common/tasks/letsencrypt.yml
@@ -1,0 +1,44 @@
+---
+
+- name: ensure letsencrypt acme-challenge path
+  file:
+    path: "{{ ssl_webroot_path }}"
+    state: "directory"
+    mode: 0755
+  sudo: yes
+
+- name: unlink app nginx config
+  file:
+    path: "/etc/nginx/sites-enabled/{{ app_name }}.conf"
+    state: "absent"
+  sudo: true
+
+- name: create temporary nginx config
+  template:
+    src: "../templates/nginx_tmp_site.conf"
+    dest: "/etc/nginx/sites-enabled/{{ app_name }}.conf"
+  sudo: true
+
+- name: restart nginx
+  sudo: yes
+  service:
+    name: nginx
+    state: restarted
+
+- name: create (or renew) letsencrypt ssl cert
+  command: "{{ letsencrypt_command }}"
+  sudo: yes
+
+- name: setup a cron to renew the SSL cert every day
+  cron:
+    name: "renew letsencrypt cert"
+    minute: "0"
+    hour: "6,18"
+    job: "{{letsencrypt_command}}"
+  sudo: yes
+
+- name: unlink tmp nginx config
+  file:
+    path: "/etc/nginx/sites-enabled/{{ app_name }}.conf"
+    state: "absent"
+  sudo: true

--- a/deploy/playbooks/roles/common/tasks/nginx.yml
+++ b/deploy/playbooks/roles/common/tasks/nginx.yml
@@ -30,51 +30,25 @@
   action: service name=nginx enabled=true
 
 - name: create nginx site config
-  action: template src=../templates/nginx_site.conf dest=/etc/nginx/sites-available/{{ app_name }}.conf
+  template:
+    src: "../templates/nginx_site.conf"
+    dest: "/etc/nginx/sites-available/{{ app_name }}.conf"
   sudo: true
   notify:
     - restart nginx
 
+- include: ssl.yml
+  when: development_server == true
+
+- include: letsencrypt.yml
+  when: development_server == false
+
 - name: link nginx config
-  action: file src=/etc/nginx/sites-available/{{ app_name }}.conf dest=/etc/nginx/sites-enabled/{{ app_name }}.conf state=link
+  file:
+    src: "/etc/nginx/sites-available/{{ app_name }}.conf"
+    dest: "/etc/nginx/sites-enabled/{{ app_name }}.conf"
+    state: "link"
   sudo: true
-
-- name: ensure ssl certs directory
-  action: file dest=/etc/ssl/certs state=directory
-  sudo: true
-
-- name: ensure ssl private directory
-  action: file dest=/etc/ssl/private state=directory
-  sudo: true
-
-- name: check for SSL cert
-  stat: path=/etc/ssl/certs/{{ fqdn }}-bundled.crt
-  ignore_errors: true
-  register: ssl_cert
-  sudo: true
-
-- name: check for SSL key
-  stat: path=/etc/ssl/private/{{ fqdn }}.key
-  ignore_errors: true
-  register: ssl_key
-  sudo: true
-
-- name: copy SSL cert
-  copy:
-    src: "{{ ssl_cert_path }}"
-    dest: "/etc/ssl/certs/{{ fqdn }}-bundled.crt"
-    mode: 0777
-  when: ssl_cert.stat.exists == false
-  sudo: true
-  notify: restart nginx
-
-- name: copy SSL key
-  copy:
-    src: "{{ ssl_key_path }}"
-    dest: "/etc/ssl/private/{{ fqdn }}.key"
-  when: ssl_key.stat.exists == false
-  sudo: true
-  notify: restart nginx
 
 - name: ensure nginx is restarted
   sudo: true

--- a/deploy/playbooks/roles/common/tasks/ssl.yml
+++ b/deploy/playbooks/roles/common/tasks/ssl.yml
@@ -1,0 +1,30 @@
+---
+
+- name: ensure ssl certs directory
+  file:
+    dest: /etc/ssl/certs
+    state: directory
+  sudo: true
+
+- name: ensure ssl private directory
+  file:
+    dest: /etc/ssl/private
+    state: directory
+  sudo: true
+
+- name: copy SSL cert
+  copy:
+    src: "{{ ssl_cert_path }}"
+    dest: "/etc/ssl/certs/{{ fqdn }}-bundled.crt"
+    mode: 0777
+    force: no
+  sudo: true
+  notify: restart nginx
+
+- name: copy SSL key
+  copy:
+    src: "{{ ssl_key_path }}"
+    dest: "/etc/ssl/private/{{ fqdn }}.key"
+    force: no
+  sudo: true
+  notify: restart nginx

--- a/deploy/playbooks/roles/common/templates/nginx_site.conf
+++ b/deploy/playbooks/roles/common/templates/nginx_site.conf
@@ -1,10 +1,24 @@
 server {
+    server_name {{ fqdn }};
+    location '/.well-known/acme-challenge' {
+        default_type "text/plain";
+        root {{ ssl_webroot_path }};
+    }
+    location / {
+        add_header Strict-Transport-Security max-age=31536000;
+        return 301 https://$server_name$request_uri;
+    }
+}
+
+server {
     listen       443 default_server ssl;
     server_name  {{ fqdn }};
 
-    ssl_certificate     /etc/ssl/certs/{{ fqdn }}-bundled.crt;
-    ssl_certificate_key /etc/ssl/private/{{ fqdn }}.key;
+    ssl_certificate     {{ nginx_ssl_cert_path }};
+    ssl_certificate_key {{ nginx_ssl_key_path }};
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
+    ssl_prefer_server_ciphers on;
     add_header Strict-Transport-Security "max-age=31536000";
 
     access_log  /var/log/nginx/{{ app_name }}-access.log;
@@ -19,6 +33,4 @@ server {
       proxy_pass          http://127.0.0.1:8000;
       proxy_read_timeout  500;
     }
-
-
 }

--- a/deploy/playbooks/roles/common/templates/nginx_tmp_site.conf
+++ b/deploy/playbooks/roles/common/templates/nginx_tmp_site.conf
@@ -1,0 +1,7 @@
+server {
+    server_name {{ fqdn }};
+    location '/.well-known/acme-challenge' {
+        default_type "text/plain";
+        root {{ ssl_webroot_path }};
+    }
+}

--- a/deploy/playbooks/roles/common/vars/main.yml
+++ b/deploy/playbooks/roles/common/vars/main.yml
@@ -21,3 +21,4 @@ system_packages:
 ssl_requirements:
   - openssl
   - libssl-dev
+  - letsencrypt


### PR DESCRIPTION
Full letsencrypt support for shaman apps, already deployed and working.

* Adds a cron job to twice a day.
* defines a deploy_production example playbook
* sets some defaults when using letsencrypt like email address
* properly redirects all traffic to SSL trafic only
* sets more robust nginx ssl configurations 