### PR TITLE
Set guess_content_type_from_ext to False in the prod config

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -16,6 +16,7 @@ app = {
     'root': 'shaman.controllers.root.RootController',
     'modules': ['shaman'],
     'default_renderer': 'json',
+    'guess_content_type_from_ext': False,
     'hooks': [
         TransactionHook(
             models.start,


### PR DESCRIPTION
Not setting this can sometimes create a confusing bug where
controllers will return a 404.

See: https://github.com/pecan/pecan/issues/26

Signed-off-by: Andrew Schoen <aschoen@redhat.com>