### PR TITLE
mark /api/nodes/next/ as transactional

### DIFF
--- a/shaman/controllers/nodes/__init__.py
+++ b/shaman/controllers/nodes/__init__.py
@@ -2,6 +2,7 @@ import datetime
 
 from pecan import expose, abort
 from pecan.secure import secure
+from pecan.decorators import transactional
 
 from shaman.models import Node
 from shaman.auth import basic_auth
@@ -44,6 +45,7 @@ class NodesController(object):
         return resp
 
     @secure(basic_auth)
+    @transactional()
     @expose(method='GET', content_type="text/plain")
     def next(self):
         next_node = get_next_node()

--- a/shaman/controllers/nodes/__init__.py
+++ b/shaman/controllers/nodes/__init__.py
@@ -37,7 +37,7 @@ class NodeController(object):
 
 class NodesController(object):
 
-    @expose(generic=True, template='json')
+    @expose(template='json')
     def index(self):
         resp = {}
         for node in Node.query.all():
@@ -46,7 +46,7 @@ class NodesController(object):
 
     @secure(basic_auth)
     @transactional()
-    @expose(method='GET', content_type="text/plain")
+    @expose(content_type="text/plain")
     def next(self):
         next_node = get_next_node()
         if not next_node:

--- a/shaman/tests/controllers/test_nodes.py
+++ b/shaman/tests/controllers/test_nodes.py
@@ -43,10 +43,11 @@ class TestNodesContoller(object):
         assert n.last_check.time() > last_check
 
     def test_get_next_node_succeeds(self, session, monkeypatch):
-        node = Node("chacra.ceph.com")
+        Node("chacra.ceph.com")
         session.commit()
 
         def _get_next_node():
+            node = Node.get(1)
             return node
 
         monkeypatch.setattr(nodes, "get_next_node", _get_next_node)


### PR DESCRIPTION
This method uses GET but needs to write to the database, so
we'll mark it as transactional using pecan.decorators.transactional.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>