### PR TITLE
adds the chacra_verify_ssl config option

### DIFF
--- a/deploy/playbooks/examples/deploy_production.yml
+++ b/deploy/playbooks/examples/deploy_production.yml
@@ -96,5 +96,6 @@
      nginx_ssl_key_path: "/etc/letsencrypt/live/{{ fqdn }}/privkey.pem"
      api_user: "admin"
      api_key: "secret"
+     chacra_verify_ssl: False
   tags:
     - deploy_app

--- a/deploy/playbooks/examples/deploy_vagrant.yml
+++ b/deploy/playbooks/examples/deploy_vagrant.yml
@@ -96,5 +96,6 @@
      nginx_ssl_key_path: "/etc/ssl/private/{{ fqdn }}.key"
      api_user: "admin"
      api_key: "secret"
+     chacra_verify_ssl: False
   tags:
     - deploy_app

--- a/deploy/playbooks/roles/common/defaults/main.yml
+++ b/deploy/playbooks/roles/common/defaults/main.yml
@@ -7,3 +7,4 @@ ssl_webroot_path: "/var/www/{{ fqdn }}"
 letsencrypt_command: "letsencrypt certonly --webroot -w {{ ssl_webroot_path }} -d {{ fqdn }} --email {{ ssl_support_email }} --agree-tos --renew-by-default"
 ssl_cert_path: "files/ssl/dev/ssl.crt"
 ssl_key_path: "files/ssl/dev/ssl.key"
+chacra_verify_ssl: False

--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -62,6 +62,8 @@ logging = {
 # if this file exists the check at /_health/ will fail
 fail_check_trigger_path = "/tmp/fail_check"
 
+chacra_verify_ssl = {{ chacra_verify_ssl|default(False) }}
+
 # production Basic HTTP Auth credentials are imported from prod_api_creds.py
 
 # production database configurations are imported from prod_db.py

--- a/shaman/util.py
+++ b/shaman/util.py
@@ -39,7 +39,8 @@ def is_node_healthy(node):
     marked down and removed from the pool.
     """
     check_url = "https://{}/health/".format(node.host)
-    r = requests.get(check_url)
+    verify_ssl = getattr(conf, "chacra_verify_ssl", False)
+    r = requests.get(check_url, verify=verify_ssl)
     node.last_check = datetime.datetime.utcnow()
     if not r.ok:
         node.down_count = node.down_count + 1


### PR DESCRIPTION
This allows us to optionally tell shaman to not verify ssl when pinging
a chacra nodes health check url. This means we can use self-signed certs
with the chacra instances until we can get a proper ssl cert for those
nodes.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>