### PR TITLE
ansible: renwal command should accept TOS and use the support email

### DIFF
--- a/deploy/playbooks/roles/common/tasks/letsencrypt.yml
+++ b/deploy/playbooks/roles/common/tasks/letsencrypt.yml
@@ -34,7 +34,7 @@
     name: "renew letsencrypt cert"
     minute: "23"
     hour: "6,18"
-    job: "letsencrypt renew"
+    job: "letsencrypt renew --email {{ ssl_support_email }} --agree-tos"
   sudo: yes
 
 - name: unlink tmp nginx config


### PR DESCRIPTION
Signed-off-by: Alfredo Deza <adeza@redhat.com>