### PR TITLE
various fixes for /api/repos/

### DIFF
--- a/shaman/controllers/repos/distros.py
+++ b/shaman/controllers/repos/distros.py
@@ -14,7 +14,8 @@ class DistroVersionController(object):
             ref=request.context['ref'],
             sha1=request.context['sha1'],
             distro=request.context['distro'],
-            distro_version=distro_version_name).all()
+            distro_version=distro_version_name,
+            flavor='default').all()
 
     @expose(generic=True, template='json')
     def index(self):
@@ -22,9 +23,7 @@ class DistroVersionController(object):
 
     @index.when(method='GET', template='json')
     def index_get(self):
-        if 'default' in [r.flavor for r in self.repos]:
-            return ['default']
-        return []
+        return [r for r in self.repos]
 
     flavors = _flavors.FlavorsController()
 

--- a/shaman/models/repos.py
+++ b/shaman/models/repos.py
@@ -61,6 +61,7 @@ class Repo(Base):
             distro_version=self.distro_version,
             modified=self.modified,
             status=self.status,
+            flavor=self.flavor,
         )
 
 

--- a/shaman/tests/controllers/test_repos.py
+++ b/shaman/tests/controllers/test_repos.py
@@ -139,7 +139,8 @@ class TestDistroVersionController(object):
     def test_get_existing_sha1(self, session):
         session.app.post_json('/api/repos/ceph/', params=base_repo_data())
         result = session.app.get('/api/repos/ceph/jewel/45107e21c568dd033c2f0a3107dec8f0b0e58374/ubuntu/xenial/')
-        assert result.json == ["default"]
+        assert result.json[0]['distro_version'] == 'xenial'
+        assert result.json[0]['flavor'] == 'default'
 
 
 class TestFlavorsController(object):


### PR DESCRIPTION
- the DistroVersionController should show a list of 'default' flavor repos, instead of the string 'default'

- adds the flavor field to Repo.__Json__ show it shows in the api output