### PR TITLE
adds support for deleting repos

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -31,6 +31,7 @@ app = {
 }
 
 logging = {
+    'disable_existing_loggers': False,
     'loggers': {
         'root': {'level': 'INFO', 'handlers': ['console']},
         'shaman': {'level': 'DEBUG', 'handlers': ['console']},

--- a/shaman/controllers/repos/projects.py
+++ b/shaman/controllers/repos/projects.py
@@ -47,6 +47,9 @@ class ProjectController(object):
                 chacra_url=chacra_url,
             )
             repo = models.get_or_create(Repo, **data)
+        if request.json["status"] == "deleted":
+            repo.delete()
+            return {}
         update_data = dict(
             status=request.json["status"],
             url=request.json.get("url", ""),

--- a/shaman/tests/controllers/test_repos.py
+++ b/shaman/tests/controllers/test_repos.py
@@ -88,6 +88,15 @@ class TestProjectController(object):
         result = session.app.post_json('/api/repos/ceph/', params=new_data)
         assert Repo.get(1).status == "ready"
 
+    def test_delete_a_repo(self, session):
+        result = session.app.post_json('/api/repos/ceph/', params=self.repo_data)
+        assert result.status_int == 200
+        assert Repo.get(1).status == "requested"
+        new_data = self.repo_data.copy()
+        new_data["status"] = "deleted"
+        result = session.app.post_json('/api/repos/ceph/', params=new_data)
+        assert not Repo.get(1)
+
     def test_update_a_repo_url(self, session):
         result = session.app.post_json('/api/repos/ceph/', params=self.repo_data)
         assert result.status_int == 200


### PR DESCRIPTION
If the status 'deleted' is given to /api/repos/ then shaman will delete that repo from the database.

I've also set ``disable_existing_loggers=False`` in the prod config so that we can see sqlalchemy logs.