### PR TITLE
reset down_count and healthy when a node registers with shaman

### DIFF
--- a/shaman/controllers/nodes/__init__.py
+++ b/shaman/controllers/nodes/__init__.py
@@ -32,6 +32,8 @@ class NodeController(object):
         if not self.node:
             self.node = models.get_or_create(Node, host=self.host)
         self.node.last_check = datetime.datetime.utcnow()
+        self.node.down_count = 0
+        self.node.healthy = True
         return {}
 
 

--- a/shaman/tests/controllers/test_nodes.py
+++ b/shaman/tests/controllers/test_nodes.py
@@ -42,6 +42,24 @@ class TestNodesContoller(object):
         n = Node.get(1)
         assert n.last_check.time() > last_check
 
+    def test_updates_down_count(self, session):
+        session.app.post("/api/nodes/chacra.ceph.com/")
+        n = Node.get(1)
+        n.down_count = 2
+        session.commit()
+        session.app.post("/api/nodes/chacra.ceph.com/")
+        n = Node.get(1)
+        assert n.down_count == 0
+
+    def test_updates_healthy(self, session):
+        session.app.post("/api/nodes/chacra.ceph.com/")
+        n = Node.get(1)
+        n.healthy = False
+        session.commit()
+        session.app.post("/api/nodes/chacra.ceph.com/")
+        n = Node.get(1)
+        assert n.healthy
+
     def test_get_next_node_succeeds(self, session, monkeypatch):
         Node("chacra.ceph.com")
         session.commit()


### PR DESCRIPTION
When a node is unhealthy and is fixed it should rejoin the pool with
down_count set to 0 and healthy=True.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>