### PR TITLE
repos should always be ordered by modified DESC

### DIFF
--- a/shaman/controllers/repos/distros.py
+++ b/shaman/controllers/repos/distros.py
@@ -1,6 +1,7 @@
 from pecan import request, expose, abort
 from shaman.models import Project, Repo
 from shaman.controllers.repos import flavors as _flavors
+from sqlalchemy import desc
 
 
 class DistroVersionController(object):
@@ -15,7 +16,7 @@ class DistroVersionController(object):
             sha1=request.context['sha1'],
             distro=request.context['distro'],
             distro_version=distro_version_name,
-            flavor='default').all()
+            flavor='default').order_by(desc(Repo.modified)).all()
 
     @expose(generic=True, template='json')
     def index(self):

--- a/shaman/controllers/repos/flavors.py
+++ b/shaman/controllers/repos/flavors.py
@@ -1,5 +1,6 @@
 from pecan import request, expose, abort
 from shaman.models import Project, Repo
+from sqlalchemy import desc
 
 
 class FlavorController(object):
@@ -13,7 +14,7 @@ class FlavorController(object):
             sha1=request.context['sha1'],
             distro=request.context['distro'],
             distro_version=request.context['distro_version'],
-            flavor=flavor_name).all()
+            flavor=flavor_name).order_by(desc(Repo.modified)).all()
 
     @expose(generic=True, template='json')
     def index(self):


### PR DESCRIPTION
The /api/search/ endpoint was ordering by modified DESC but the listing
endpoints were not.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>