### PR TITLE
makes POST /api/builds/$project_name update an existing build

### DIFF
--- a/shaman/tests/controllers/test_builds.py
+++ b/shaman/tests/controllers/test_builds.py
@@ -33,11 +33,9 @@ class TestProjectController(object):
 
     def test_update_build(self, session):
         session.app.post_json('/api/builds/ceph/', params=self.data)
-        data = dict(
-            url="jenkins.ceph.com/build",
-            status="completed",
-        )
-        result = session.app.put_json('/api/builds/ceph/', params=data)
+        data = self.data.copy()
+        data['status'] = "completed"
+        result = session.app.post_json('/api/builds/ceph/', params=data)
         assert result.status_int == 200
         build = Build.get(1)
         assert build.status == "completed"


### PR DESCRIPTION
We're changing it so that POST will create and update so that we can
simplify the logic in jenkins when posting build information.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>