### PR TITLE
verify chacra node health when it registers

### DIFF
--- a/shaman/controllers/api/nodes/__init__.py
+++ b/shaman/controllers/api/nodes/__init__.py
@@ -6,7 +6,7 @@ from pecan.decorators import transactional
 
 from shaman.models import Node
 from shaman.auth import basic_auth
-from shaman.util import get_next_node
+from shaman.util import get_next_node, check_node_health
 from shaman import models
 
 
@@ -32,8 +32,11 @@ class NodeController(object):
         if not self.node:
             self.node = models.get_or_create(Node, host=self.host)
         self.node.last_check = datetime.datetime.utcnow()
-        self.node.down_count = 0
-        self.node.healthy = True
+        if not check_node_health(self.node):
+            self.node.healthy = False
+        else:
+            self.node.down_count = 0
+            self.node.healthy = True
         return {}
 
 


### PR DESCRIPTION
When a chacra node registers with the shaman we should verify that it's healthy before adding it to the pool. This is also helpful when you want to force a node into maintenance mode.

See: http://tracker.ceph.com/issues/17623