### PR TITLE
UI: limit the amount of builds listed to 1000

### DIFF
--- a/shaman/controllers/builds/__init__.py
+++ b/shaman/controllers/builds/__init__.py
@@ -1,6 +1,9 @@
-from pecan import expose, request, abort
+from pecan import expose, request, abort, conf
 from shaman.models import Build, Project
 from sqlalchemy import desc
+
+
+BUILD_LIMIT = getattr(conf, "build_limit", 1000)
 
 
 class BuildController(object):
@@ -42,7 +45,7 @@ class FlavorController(object):
             ref=request.context['ref'],
             sha1=request.context['sha1'],
             flavor=self.flavor_name
-        ).order_by(desc(Build.modified)).all()
+        ).order_by(desc(Build.modified)).limit(BUILD_LIMIT).all()
 
         return dict(
             project_name=self.project.name,
@@ -72,7 +75,7 @@ class SHA1Controller(object):
             project=self.project,
             ref=request.context['ref'],
             sha1=self.sha1_name
-        ).order_by(desc(Build.modified)).all()
+        ).order_by(desc(Build.modified)).limit(BUILD_LIMIT).all()
 
         distinct = {
             "flavors": list(set([b.flavor for b in builds]))
@@ -106,7 +109,7 @@ class RefController(object):
         builds = Build.filter_by(
             project=self.project,
             ref=self.ref_name
-        ).order_by(desc(Build.modified)).all()
+        ).order_by(desc(Build.modified)).limit(BUILD_LIMIT).all()
 
         distinct = {
             "sha1s": list(set([b.sha1 for b in builds]))
@@ -138,7 +141,7 @@ class ProjectController(object):
 
     @expose('jinja:builds.html')
     def index(self):
-        builds = Build.filter_by(project=self.project).order_by(desc(Build.modified)).all()
+        builds = Build.filter_by(project=self.project).order_by(desc(Build.modified)).limit(BUILD_LIMIT).all()
         distinct = {
             "refs": list(set([b.ref for b in builds]))
         }
@@ -159,7 +162,7 @@ class BuildsController(object):
 
     @expose('jinja:builds.html')
     def index(self):
-        builds = Build.query.order_by(desc(Build.modified)).all()
+        builds = Build.query.order_by(desc(Build.modified)).limit(BUILD_LIMIT).all()
         distinct = {
             "projects": list(set([b.project.name for b in builds]))
         }


### PR DESCRIPTION
We're starting to get quite a few builds in the system and the listing pages are starting to slow down a bit. This limits the amount of builds shown in the UI, but all builds are still available through the api endpoints.