### PR TITLE
repo endpoints to redirect to chacra

### DIFF
--- a/shaman/controllers/api/repos/flavors.py
+++ b/shaman/controllers/api/repos/flavors.py
@@ -1,4 +1,5 @@
-from pecan import request, expose, abort
+import os
+from pecan import request, expose, abort, redirect
 from shaman.models import Project, Repo
 from sqlalchemy import desc
 
@@ -8,13 +9,14 @@ class FlavorController(object):
     def __init__(self, flavor_name):
         self.flavor_name = flavor_name
         self.project = Project.query.get(request.context['project_id'])
-        self.repos = Repo.query.filter_by(
+        self.repo_query = Repo.query.filter_by(
             project=self.project,
             ref=request.context['ref'],
             sha1=request.context['sha1'],
             distro=request.context['distro'],
             distro_version=request.context['distro_version'],
-            flavor=flavor_name).order_by(desc(Repo.modified)).all()
+            flavor=flavor_name).order_by(desc(Repo.modified))
+        self.repos = self.repo_query.all()
 
     @expose(generic=True, template='json')
     def index(self):
@@ -23,6 +25,17 @@ class FlavorController(object):
     @index.when(method='GET', template='json')
     def index_get(self):
         return [r for r in self.repos]
+
+    @expose()
+    def repo(self):
+        # requires the repository to be fully available on a remote chacra
+        # instance for a proper redirect. Otherwise it will fail explicitly
+        repo = self.repo_query.filter_by(status='ready').first()
+        if not repo:
+            abort(504, detail="no repository is available yet")
+        redirect(
+            os.path.join(repo.chacra_url, 'repo')
+        )
 
 
 class FlavorsController(object):

--- a/shaman/controllers/api/repos/sha1s.py
+++ b/shaman/controllers/api/repos/sha1s.py
@@ -1,5 +1,6 @@
 from pecan import request, expose, abort
 from shaman.models import Project, Repo
+from sqlalchemy import desc
 from shaman.controllers.api.repos import distros
 
 
@@ -7,12 +8,15 @@ class SHA1Controller(object):
 
     def __init__(self, sha1_name):
         self.sha1_name = sha1_name
-        request.context['sha1'] = sha1_name
         self.project = Project.query.get(request.context['project_id'])
-        self.repos = Repo.query.filter_by(
-            project=self.project,
-            ref=request.context['ref'],
-            sha1=sha1_name).all()
+        self.repos = Repo.query.filter_by(project=self.project, ref=request.context['ref'])
+        if sha1_name != 'latest':
+            self.repos = self.repos.filter_by(sha1=sha1_name).all()
+            request.context['sha1'] = sha1_name
+        else:
+            latest_repo = self.repos.order_by(desc(Repo.modified)).first()
+            self.repos = [latest_repo]
+            request.context['sha1'] = latest_repo.sha1
 
     @expose(generic=True, template='json')
     def index(self):

--- a/shaman/tests/controllers/test_repos.py
+++ b/shaman/tests/controllers/test_repos.py
@@ -127,15 +127,18 @@ class TestProjectController(object):
         assert len(repo.archs) == 2
 
 
-def base_repo_data():
+def base_repo_data(**kw):
+    distro = kw.get('distro', 'ubuntu')
+    sha1 = kw.get('sha1', '45107e21c568dd033c2f0a3107dec8f0b0e58374')
+    status = kw.get('status', 'requested')
     return dict(
         ref="jewel",
-        sha1="45107e21c568dd033c2f0a3107dec8f0b0e58374",
+        sha1=sha1,
         flavor="default",
-        distro="ubuntu",
+        distro=distro,
         distro_version="xenial",
-        chacra_url="chacra.ceph.com/repos/ceph/jewel/45107e21c568dd033c2f0a3107dec8f0b0e58374/ubuntu/xenial/",
-        status="requested",
+        chacra_url="chacra.ceph.com/repos/ceph/jewel/{sha1}/{distro}/xenial/".format(sha1=sha1, distro=distro),
+        status=status,
         archs=["x86_64", "arm64"]
     )
 
@@ -163,6 +166,20 @@ class TestSHA1Controller(object):
         session.app.post_json('/api/repos/ceph/', params=base_repo_data())
         result = session.app.get('/api/repos/ceph/jewel/45107e21c568dd033c2f0a3107dec8f0b0e58374/')
         assert result.json == ["ubuntu"]
+
+    def test_get_latest_sha1(self, session):
+        session.app.post_json('/api/repos/ceph/', params=base_repo_data())
+        result = session.app.get('/api/repos/ceph/jewel/latest/')
+        assert result.json == ["ubuntu"]
+
+    def test_get_one_latest_sha1(self, session):
+        session.app.post_json('/api/repos/ceph/', params=base_repo_data())
+        session.app.post_json(
+            '/api/repos/ceph/',
+            params=base_repo_data(distro='centos', sha1='aaaaa')
+        )
+        result = session.app.get('/api/repos/ceph/jewel/latest/')
+        assert result.json == ["centos"]
 
 
 class TestDistroController(object):
@@ -195,6 +212,15 @@ class TestDistroVersionController(object):
         assert result.json[0]['distro_codename'] == 'xenial'
         assert result.json[0]['flavor'] == 'default'
 
+    def test_get_latest_repo_unavailable(self, session):
+        session.app.post_json('/api/repos/ceph/', params=base_repo_data())
+        result = session.app.get('/api/repos/ceph/jewel/latest/ubuntu/xenial/repo/', expect_errors=True)
+        assert result.status_int == 504
+
+    def test_get_latest_repo_ready(self, session):
+        session.app.post_json('/api/repos/ceph/', params=base_repo_data(status='ready'))
+        result = session.app.get('/api/repos/ceph/jewel/latest/ubuntu/xenial/repo/', expect_errors=True)
+        assert result.status_int == 302
 
 class TestFlavorsController(object):
 
@@ -217,3 +243,16 @@ class TestFlavorController(object):
         assert result.json[0]['ref'] == 'jewel'
         assert result.json[0]['sha1'] == '45107e21c568dd033c2f0a3107dec8f0b0e58374'
         assert sorted(result.json[0]['archs']) == sorted(["arm64", "x86_64"])
+
+    def test_get_latest_repo_unavailable(self, session):
+        session.app.post_json('/api/repos/ceph/', params=base_repo_data())
+        result = session.app.get(
+            '/api/repos/ceph/jewel/latest/ubuntu/xenial/flavors/default/repo/',
+            expect_errors=True
+        )
+        assert result.status_int == 504
+
+    def test_get_latest_repo_ready(self, session):
+        session.app.post_json('/api/repos/ceph/', params=base_repo_data(status='ready'))
+        result = session.app.get('/api/repos/ceph/jewel/latest/ubuntu/xenial/flavors/default/repo/', expect_errors=True)
+        assert result.status_int == 302


### PR DESCRIPTION
Should help with: https://github.com/ceph/ceph-ansible/issues/1137

When a request comes in using 'latest' instead of an actual sha1, the `repo/` endpoint will redirect to the repo file on whatever chacra instance it was built