### PR TITLE
deploy: prefix nginx site config with "01"

### DIFF
--- a/deploy/playbooks/roles/common/tasks/nginx.yml
+++ b/deploy/playbooks/roles/common/tasks/nginx.yml
@@ -32,7 +32,7 @@
 - name: create nginx site config
   template:
     src: "../templates/nginx_site.conf"
-    dest: "/etc/nginx/sites-available/{{ app_name }}.conf"
+    dest: "/etc/nginx/sites-available/01-{{ app_name }}.conf"
   sudo: true
   notify:
     - restart nginx


### PR DESCRIPTION
For non-SNI HTTP clients, nginx will serve whichever TLS certificate is specified first in the configuration. Notably, this includes Python v2.7.5 on Trusty.

When we have both `grafana.conf` and `shaman.conf` in `/etc/nginx/sites-enabled/`, this causes nginx to serve grafana.ceph.com's TLS certificate to non-SNI clients. This causes Trusty Python clients to fail to validate https://shaman.ceph.com.

With this change, nginx will read shaman's nginx configuration before any other sites. This will cause nginx to serve the shaman.ceph.com TLS cert to non-SNI clients.