### PR TITLE
repos: do not filter by ?arch=x86_64 by default

### DIFF
--- a/shaman/controllers/api/repos/distros.py
+++ b/shaman/controllers/api/repos/distros.py
@@ -31,10 +31,12 @@ class DistroVersionController(object):
 
     @expose()
     def repo(self, **kw):
-        arch = kw.get('arch', 'x86_64')
+        arch = kw.get('arch')
         # requires the repository to be fully available on a remote chacra
         # instance for a proper redirect. Otherwise it will fail explicitly
-        repo = self.repo_query.filter_by(status='ready').join(Arch).filter(Arch.name == arch).first()
+        repo = self.repo_query.filter_by(status='ready').first()
+        if arch:
+            repo = self.repo_query.filter_by(status='ready').join(Arch).filter(Arch.name == arch).first()
         if not repo:
             abort(504, "no repository is ready for: %s/%s" % (self.project.name, self.ref_name))
         redirect(

--- a/shaman/tests/controllers/test_builds.py
+++ b/shaman/tests/controllers/test_builds.py
@@ -52,14 +52,14 @@ class TestProjectController(object):
         data = get_build_data(status='queued', url='jenkins.ceph.com/trigger')
         session.app.post_json('/api/builds/ceph/', params=data)
         data = get_build_data(status='completed')
-        result = session.app.post_json('/api/builds/ceph/', params=data)
+        session.app.post_json('/api/builds/ceph/', params=data)
         assert len(Build.query.all()) == 1
 
     def test_update_queued_build_is_completed(self, session):
         data = get_build_data(status='queued', url='jenkins.ceph.com/trigger')
         session.app.post_json('/api/builds/ceph/', params=data)
         data = get_build_data(status='completed')
-        result = session.app.post_json('/api/builds/ceph/', params=data)
+        session.app.post_json('/api/builds/ceph/', params=data)
         assert Build.get(1).status == 'completed'
 
     def test_lists_refs(self, session):

--- a/shaman/tests/controllers/test_repos.py
+++ b/shaman/tests/controllers/test_repos.py
@@ -132,6 +132,7 @@ def base_repo_data(**kw):
     sha1 = kw.get('sha1', '45107e21c568dd033c2f0a3107dec8f0b0e58374')
     status = kw.get('status', 'ready')
     ref = kw.get('ref', 'jewel')
+    archs = kw.get('archs', ["x86_64", "arm64"])
     return dict(
         ref=ref,
         sha1=sha1,
@@ -140,7 +141,7 @@ def base_repo_data(**kw):
         distro_version="xenial",
         chacra_url="chacra.ceph.com/repos/ceph/jewel/{sha1}/{distro}/xenial/".format(sha1=sha1, distro=distro),
         status=status,
-        archs=["x86_64", "arm64"]
+        archs=archs,
     )
 
 
@@ -242,6 +243,11 @@ class TestDistroVersionController(object):
         result = session.app.get('/api/repos/ceph/jewel/latest/ubuntu/xenial/repo/', expect_errors=True)
         assert result.status_int == 302
 
+    def test_get_latest_repo_ready_noarch(self, session):
+        session.app.post_json('/api/repos/ceph/', params=base_repo_data(status='ready', archs=["noarch"]))
+        result = session.app.get('/api/repos/ceph/jewel/latest/ubuntu/xenial/repo/', expect_errors=True)
+        assert result.status_int == 302
+
     def test_get_latest_repo_valid_arch_ready(self, session):
         session.app.post_json('/api/repos/ceph/', params=base_repo_data(status='ready'))
         result = session.app.get('/api/repos/ceph/jewel/latest/ubuntu/xenial/repo/?arch=arm64', expect_errors=True)
@@ -290,6 +296,11 @@ class TestFlavorController(object):
 
     def test_get_latest_repo_ready(self, session):
         session.app.post_json('/api/repos/ceph/', params=base_repo_data(status='ready'))
+        result = session.app.get('/api/repos/ceph/jewel/latest/ubuntu/xenial/flavors/default/repo/', expect_errors=True)
+        assert result.status_int == 302
+
+    def test_get_latest_repo_ready_noarch(self, session):
+        session.app.post_json('/api/repos/ceph/', params=base_repo_data(status='ready', archs=["noarch"]))
         result = session.app.get('/api/repos/ceph/jewel/latest/ubuntu/xenial/flavors/default/repo/', expect_errors=True)
         assert result.status_int == 302
 


### PR DESCRIPTION
This results in some unexpected behavior when repos are built for
``noarch`` and the /repos endpoint tries to filter by x86_64 and fails.
Instead we should not filter by arch at all if ``?arch`` is not explicitly
given.

Resolves: https://github.com/ceph/shaman/issues/89