### PR TITLE
fix intermittent 504 when requesting the latest for a repo

### DIFF
--- a/shaman/controllers/api/repos/refs.py
+++ b/shaman/controllers/api/repos/refs.py
@@ -23,4 +23,4 @@ class RefController(object):
 
     @expose()
     def _lookup(self, sha1_name, *remainder):
-        return sha1s.SHA1Controller(sha1_name), remainder
+        return sha1s.SHA1Controller(sha1_name, *remainder), remainder

--- a/shaman/controllers/api/repos/sha1s.py
+++ b/shaman/controllers/api/repos/sha1s.py
@@ -6,7 +6,7 @@ from shaman.controllers.api.repos import distros
 
 class SHA1Controller(object):
 
-    def __init__(self, sha1_name):
+    def __init__(self, sha1_name, *args):
         self.sha1_name = sha1_name
         self.ref_name = request.context['ref']
         self.project = Project.query.get(request.context['project_id'])
@@ -15,6 +15,17 @@ class SHA1Controller(object):
             self.repos = self.repos.filter_by(sha1=sha1_name).all()
             request.context['sha1'] = sha1_name
         else:
+            # if the url contains distro and distro_version we want
+            # to filter by that as well. This avoids a bug where a sha1
+            # would be used for a distro/distro_version that might not have a
+            # ready repo, resulting in the further controllers giving a 504
+            if len(args) >= 2:
+                self.repos = Repo.query.filter_by(
+                    project=self.project,
+                    ref=self.ref_name,
+                    distro=args[0],
+                    distro_version=args[1],
+                )
             latest_repo = self.repos.filter_by(status='ready').order_by(desc(Repo.modified)).first()
             if not latest_repo:
                 abort(504, "no repository is ready for: %s/%s" % (self.project.name, self.ref_name))

--- a/shaman/tests/controllers/test_repos.py
+++ b/shaman/tests/controllers/test_repos.py
@@ -243,6 +243,15 @@ class TestDistroVersionController(object):
         result = session.app.get('/api/repos/ceph/jewel/latest/ubuntu/xenial/repo/', expect_errors=True)
         assert result.status_int == 302
 
+    def test_get_latest_repo_sha1_not_ready_for_distro(self, session):
+        # this tests for a regression where the latest sha1 that is picked for a distro does not
+        # have a ready repo and a 504 is eventually given
+        session.app.post_json('/api/repos/ceph/', params=base_repo_data(status='ready', sha1="0"))
+        session.app.post_json('/api/repos/ceph/', params=base_repo_data(status='ready', sha1="1", distro="test"))
+        session.app.post_json('/api/repos/ceph/', params=base_repo_data(status='building', sha1="1"))
+        result = session.app.get('/api/repos/ceph/jewel/latest/ubuntu/xenial/repo/?arch=x86_64', expect_errors=True)
+        assert result.status_int == 302
+
     def test_get_latest_repo_ready_noarch(self, session):
         session.app.post_json('/api/repos/ceph/', params=base_repo_data(status='ready', archs=["noarch"]))
         result = session.app.get('/api/repos/ceph/jewel/latest/ubuntu/xenial/repo/', expect_errors=True)
@@ -297,6 +306,15 @@ class TestFlavorController(object):
     def test_get_latest_repo_ready(self, session):
         session.app.post_json('/api/repos/ceph/', params=base_repo_data(status='ready'))
         result = session.app.get('/api/repos/ceph/jewel/latest/ubuntu/xenial/flavors/default/repo/', expect_errors=True)
+        assert result.status_int == 302
+
+    def test_get_latest_repo_sha1_not_ready_for_distro(self, session):
+        # this tests for a regression where the latest sha1 that is picked for a distro does not
+        # have a ready repo and a 504 is eventually given
+        session.app.post_json('/api/repos/ceph/', params=base_repo_data(status='ready', sha1="0"))
+        session.app.post_json('/api/repos/ceph/', params=base_repo_data(status='ready', sha1="1", distro="test"))
+        session.app.post_json('/api/repos/ceph/', params=base_repo_data(status='building', sha1="1"))
+        result = session.app.get('/api/repos/ceph/jewel/latest/ubuntu/xenial/flavors/default/repo/?arch=x86_64', expect_errors=True)
         assert result.status_int == 302
 
     def test_get_latest_repo_ready_noarch(self, session):


### PR DESCRIPTION
This resolves a situation where using the 'latest' sha1 feature in the repos
endpoint would result in a 504 even if there are repos built for that project/ref.

For example, the following url would give a 504 intermittently even though there
are many builds for the ceph master branch for xenial:
https://shaman.ceph.com/api/repos/ceph/master/latest/ubuntu/xenial/repo/

This scenario would occur when:

- a repo for ceph/master/sah1Y was built and completed for xenial
- a repo for ceph/master/sha1X was built and completed for centos7
- a repo for ceph/master/sha1X is still being built for xenial
- a request to the repo endpoint for ceph/master/latest/ubuntu/xenial
would select sha1x instead of sha1Y which would *actually* be the latest
sha1 that is ready for use.

This patch fixes that by having the sha1 contoller filter by distro and
distro_version if sha1=latest is used.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>