### PR TITLE
Adds a new redirect endpoint to repo contents

### DIFF
--- a/shaman/controllers/api/repos/distros.py
+++ b/shaman/controllers/api/repos/distros.py
@@ -1,6 +1,6 @@
-import os
-from pecan import request, expose, abort, redirect
-from shaman.models import Project, Repo, Arch
+from pecan import request, expose, abort
+from shaman.models import Project, Repo
+from shaman.util import redirect_to_repo
 from sqlalchemy import desc
 from shaman.controllers.api.repos import flavors as _flavors
 
@@ -31,16 +31,11 @@ class DistroVersionController(object):
 
     @expose()
     def repo(self, **kw):
-        arch = kw.get('arch')
-        # requires the repository to be fully available on a remote chacra
-        # instance for a proper redirect. Otherwise it will fail explicitly
-        repo = self.repo_query.filter_by(status='ready').first()
-        if arch:
-            repo = self.repo_query.filter_by(status='ready').join(Arch).filter(Arch.name == arch).first()
-        if not repo:
-            abort(504, "no repository is ready for: %s/%s" % (self.project.name, self.ref_name))
-        redirect(
-            os.path.join(repo.chacra_url, 'repo')
+        redirect_to_repo(
+            self.repo_query,
+            self.project.name,
+            self.ref_name,
+            **kw
         )
 
     flavors = _flavors.FlavorsController()

--- a/shaman/controllers/api/repos/flavors.py
+++ b/shaman/controllers/api/repos/flavors.py
@@ -1,6 +1,6 @@
-from pecan import request, expose, abort
+from pecan import request, expose, abort, redirect
 from shaman.models import Project, Repo
-from shaman.util import redirect_to_repo
+from shaman.util import get_repo_url
 from sqlalchemy import desc
 
 
@@ -29,12 +29,28 @@ class FlavorController(object):
 
     @expose()
     def repo(self, **kw):
-        redirect_to_repo(
+        repo_url = get_repo_url(
             self.repo_query,
-            self.project.name,
-            self.ref_name,
-            **kw
+            kw.get('arch'),
         )
+        if not repo_url:
+            abort(504, "no repository is ready for: %s/%s" % (self.project.name, self.ref_name))
+        redirect(repo_url)
+
+    @expose()
+    def _default(self, arch, *args):
+        directory = None
+        if args:
+            directory = args[0]
+        repo_url = get_repo_url(
+            self.repo_query,
+            arch,
+            directory=directory,
+            repo_file=False,
+        )
+        if not repo_url:
+            abort(504, "no repository is ready for: %s/%s" % (self.project.name, self.ref_name))
+        redirect(repo_url)
 
 
 class FlavorsController(object):

--- a/shaman/controllers/api/repos/flavors.py
+++ b/shaman/controllers/api/repos/flavors.py
@@ -1,6 +1,6 @@
-import os
-from pecan import request, expose, abort, redirect
-from shaman.models import Project, Repo, Arch
+from pecan import request, expose, abort
+from shaman.models import Project, Repo
+from shaman.util import redirect_to_repo
 from sqlalchemy import desc
 
 
@@ -29,16 +29,11 @@ class FlavorController(object):
 
     @expose()
     def repo(self, **kw):
-        arch = kw.get('arch')
-        # requires the repository to be fully available on a remote chacra
-        # instance for a proper redirect. Otherwise it will fail explicitly
-        repo = self.repo_query.filter_by(status='ready').first()
-        if arch:
-            repo = self.repo_query.filter_by(status='ready').join(Arch).filter(Arch.name == arch).first()
-        if not repo:
-            abort(504, "no repository is ready for: %s/%s" % (self.project.name, self.ref_name))
-        redirect(
-            os.path.join(repo.chacra_url, 'repo')
+        redirect_to_repo(
+            self.repo_query,
+            self.project.name,
+            self.ref_name,
+            **kw
         )
 
 

--- a/shaman/util.py
+++ b/shaman/util.py
@@ -3,7 +3,7 @@ import requests
 import datetime
 import logging
 
-from pecan import conf, abort, redirect
+from pecan import conf
 from sqlalchemy import asc
 
 from shaman import models
@@ -158,15 +158,19 @@ def parse_distro_query(query):
     return result
 
 
-def redirect_to_repo(query, project_name, ref, **kw):
-    arch = kw.get('arch')
+def get_repo_url(query, arch, directory=None, repo_file=True):
     # requires the repository to be fully available on a remote chacra
     # instance for a proper redirect. Otherwise it will fail explicitly
     repo = query.filter_by(status='ready').first()
     if arch:
         repo = query.filter_by(status='ready').join(models.Arch).filter(models.Arch.name == arch).first()
     if not repo:
-        abort(504, "no repository is ready for: %s/%s" % (project_name, ref))
-    redirect(
-        os.path.join(repo.chacra_url, 'repo')
-    )
+        return None
+    repo_url = repo.url
+    if directory:
+        repo_url = os.path.join(repo.url, directory)
+    if repo_file:
+        # return a url to the chacra endpoint that prints a plain text
+        # yum or apt repo file
+        repo_url = os.path.join(repo.chacra_url, 'repo')
+    return repo_url


### PR DESCRIPTION
This new api endpoint will redirect to the actual repo contents, instead of a repo file like shaman.ceph.com/api/repo/ceph/master/latest/centos/7/repo/ would.

Instead, you can use the following endpoint:

``shaman.ceph.com/api/repo/ceph/master/latest/centos/7/$ARCH/$DIR``

``$ARCH`` is required and is used to find the correct repo, remember because of the distributed nature of chacra not all architectures exist in the same repo at the same location.

``$DIR`` is optional and can be used to redirect to a specific directory in the repo root directory. Meaning, you could link directory to the latest centos/7 SRPMS dir by doing the following:

``shaman.ceph.com/api/repo/ceph/master/latest/centos/7/x86_64/SRPMS``