### PR TITLE
accept a full path at the repo redirect endpoint

### DIFF
--- a/shaman/controllers/api/repos/distros.py
+++ b/shaman/controllers/api/repos/distros.py
@@ -41,13 +41,10 @@ class DistroVersionController(object):
 
     @expose()
     def _default(self, arch, *args):
-        directory = None
-        if args:
-            directory = args[0]
         repo_url = get_repo_url(
             self.repo_query,
             arch,
-            directory=directory,
+            path=args,
             repo_file=False,
         )
         if not repo_url:

--- a/shaman/controllers/api/repos/flavors.py
+++ b/shaman/controllers/api/repos/flavors.py
@@ -39,13 +39,10 @@ class FlavorController(object):
 
     @expose()
     def _default(self, arch, *args):
-        directory = None
-        if args:
-            directory = args[0]
         repo_url = get_repo_url(
             self.repo_query,
             arch,
-            directory=directory,
+            path=args,
             repo_file=False,
         )
         if not repo_url:

--- a/shaman/tests/controllers/test_repos.py
+++ b/shaman/tests/controllers/test_repos.py
@@ -264,7 +264,7 @@ class TestDistroVersionController(object):
 
     def test_get_latest_repo_directory_ready(self, session):
         session.app.post_json('/api/repos/ceph/', params=base_repo_data(status='ready', distro="centos", distro_version="7"))
-        result = session.app.get('/api/repos/ceph/jewel/latest/centos/7/x86_64/noarch/', expect_errors=True)
+        result = session.app.get('/api/repos/ceph/jewel/latest/centos/7/x86_64/noarch/repodata/repomd.xml', expect_errors=True)
         assert result.status_int == 302
 
     def test_get_latest_repo_sha1_not_ready_for_distro(self, session):
@@ -364,7 +364,7 @@ class TestFlavorController(object):
 
     def test_get_latest_repo_directory_ready(self, session):
         session.app.post_json('/api/repos/ceph/', params=base_repo_data(status='ready', distro="centos", distro_version="7"))
-        result = session.app.get('/api/repos/ceph/jewel/latest/centos/7/flavors/default/x86_64/noarch/', expect_errors=True)
+        result = session.app.get('/api/repos/ceph/jewel/latest/centos/7/flavors/default/x86_64/noarch/repodata/repomd.xml', expect_errors=True)
         assert result.status_int == 302
 
     def test_get_latest_repo_sha1_not_ready_for_distro(self, session):

--- a/shaman/tests/test_util.py
+++ b/shaman/tests/test_util.py
@@ -258,5 +258,11 @@ class TestGetRepoUrl(object):
     def test_redirect_to_a_directory(self, session):
         session.commit()
         query = Repo.query.filter_by(status='ready')
-        result = util.get_repo_url(query, 'x86_64', directory="SRPMS", repo_file=False)
+        result = util.get_repo_url(query, 'x86_64', path=["SRPMS"], repo_file=False)
         assert result.endswith("/SRPMS")
+
+    def test_redirect_to_a_directory_path(self, session):
+        session.commit()
+        query = Repo.query.filter_by(status='ready')
+        result = util.get_repo_url(query, 'x86_64', path=["SRPMS", "repodata", "repomd.xml"], repo_file=False)
+        assert result.endswith("/SRPMS/repodata/repomd.xml")

--- a/shaman/util.py
+++ b/shaman/util.py
@@ -158,7 +158,7 @@ def parse_distro_query(query):
     return result
 
 
-def get_repo_url(query, arch, directory=None, repo_file=True):
+def get_repo_url(query, arch, path=None, repo_file=True):
     # requires the repository to be fully available on a remote chacra
     # instance for a proper redirect. Otherwise it will fail explicitly
     repo = query.filter_by(status='ready').first()
@@ -167,8 +167,8 @@ def get_repo_url(query, arch, directory=None, repo_file=True):
     if not repo:
         return None
     repo_url = repo.url
-    if directory:
-        repo_url = os.path.join(repo.url, directory)
+    if path:
+        repo_url = os.path.join(repo.url, *path)
     if repo_file:
         # return a url to the chacra endpoint that prints a plain text
         # yum or apt repo file


### PR DESCRIPTION
When using the redirect endpoint in a yum repo '/repodata/repomd.xml'
will always be added to the url. This means we need to make sure that we
redirect to the full path given or the yum repo will break.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>