### PR TITLE
Order by build id instead of last modified

### DIFF
--- a/shaman/controllers/builds/__init__.py
+++ b/shaman/controllers/builds/__init__.py
@@ -1,6 +1,6 @@
 from pecan import expose, request, abort, conf
 from shaman.models import Build, Project
-from sqlalchemy import desc
+from sqlalchemy import desc, Integer
 
 
 BUILD_LIMIT = getattr(conf, "build_limit", 1000)
@@ -45,7 +45,7 @@ class FlavorController(object):
             ref=request.context['ref'],
             sha1=request.context['sha1'],
             flavor=self.flavor_name
-        ).order_by(desc(Build.modified)).limit(BUILD_LIMIT).all()
+        ).order_by(desc(Build.id)).limit(BUILD_LIMIT).all()
 
         return dict(
             project_name=self.project.name,
@@ -75,7 +75,7 @@ class SHA1Controller(object):
             project=self.project,
             ref=request.context['ref'],
             sha1=self.sha1_name
-        ).order_by(desc(Build.modified)).limit(BUILD_LIMIT).all()
+        ).order_by(desc(Build.id)).limit(BUILD_LIMIT).all()
 
         distinct = {
             "flavors": list(set([b.flavor for b in builds]))
@@ -109,7 +109,7 @@ class RefController(object):
         builds = Build.filter_by(
             project=self.project,
             ref=self.ref_name
-        ).order_by(desc(Build.modified)).limit(BUILD_LIMIT).all()
+        ).order_by(desc(Build.id)).limit(BUILD_LIMIT).all()
 
         distinct = {
             "sha1s": list(set([b.sha1 for b in builds]))
@@ -141,7 +141,8 @@ class ProjectController(object):
 
     @expose('jinja:builds.html')
     def index(self):
-        builds = Build.filter_by(project=self.project).order_by(desc(Build.modified)).limit(BUILD_LIMIT).all()
+        builds = Build.filter_by(project=self.project).order_by(
+            desc(Build.id)).limit(BUILD_LIMIT).all()
         distinct = {
             "refs": list(set([b.ref for b in builds]))
         }
@@ -162,7 +163,7 @@ class BuildsController(object):
 
     @expose('jinja:builds.html')
     def index(self):
-        builds = Build.query.order_by(desc(Build.modified)).limit(BUILD_LIMIT).all()
+        builds = Build.query.order_by(desc(Build.id)).limit(BUILD_LIMIT).all()
         distinct = {
             "projects": list(set([b.project.name for b in builds]))
         }

--- a/shaman/tests/controllers/test_builds.py
+++ b/shaman/tests/controllers/test_builds.py
@@ -1,4 +1,4 @@
-from shaman.models import Build
+from shaman.models import Build, Project, commit
 
 
 def get_build_data(**kw):
@@ -21,6 +21,56 @@ def get_build_data(**kw):
 
 
 class TestProjectController(object):
+
+    def setup(self):
+        self.data = get_build_data()
+
+    def test_list_ref_by_id(self, session):
+        project = Project(name='ceph')
+        Build(build_id=1, project=project, ref='master')
+        Build(build_id=2, project=project, ref='master')
+        Build(build_id=100, project=project, ref='master')
+        commit()
+        result = session.app.get('/builds/ceph/master/')
+        assert result.namespace['builds'][0].build_id == '100'
+        assert result.namespace['builds'][1].build_id == '2'
+        assert result.namespace['builds'][2].build_id == '1'
+
+    def test_list_builds_by_id(self, session):
+        project = Project(name='ceph')
+        Build(build_id=1, project=project, ref='master')
+        Build(build_id=2, project=project, ref='master')
+        Build(build_id=100, project=project, ref='master')
+        commit()
+        result = session.app.get('/builds/ceph/')
+        assert result.namespace['builds'][0].build_id == '100'
+        assert result.namespace['builds'][1].build_id == '2'
+        assert result.namespace['builds'][2].build_id == '1'
+
+    def test_list_sha1s_by_id(self, session):
+        project = Project(name='ceph')
+        Build(build_id=1, project=project, ref='master', sha1='1234')
+        Build(build_id=2, project=project, ref='master', sha1='1234')
+        Build(build_id=100, project=project, ref='master', sha1='1234')
+        commit()
+        result = session.app.get('/builds/ceph/master/1234/')
+        assert result.namespace['builds'][0].build_id == '100'
+        assert result.namespace['builds'][1].build_id == '2'
+        assert result.namespace['builds'][2].build_id == '1'
+
+    def test_list_flavors_by_id(self, session):
+        project = Project(name='ceph')
+        Build(build_id=1, project=project, ref='master', sha1='1234', flavor='default')
+        Build(build_id=2, project=project, ref='master', sha1='1234', flavor='default')
+        Build(build_id=100, project=project, ref='master', sha1='1234', flavor='default')
+        commit()
+        result = session.app.get('/builds/ceph/master/1234/default/')
+        assert result.namespace['builds'][0].build_id == '100'
+        assert result.namespace['builds'][1].build_id == '2'
+        assert result.namespace['builds'][2].build_id == '1'
+
+
+class TestApiProjectController(object):
 
     def setup(self):
         self.data = get_build_data()


### PR DESCRIPTION
Otherwise the UI presents builds that just got updated that have nothing to do with the latest push