### PR TITLE
Truncate strings (sha1s and refs mostly)

### DIFF
--- a/shaman/controllers/builds/__init__.py
+++ b/shaman/controllers/builds/__init__.py
@@ -1,6 +1,6 @@
 from pecan import expose, request, abort, conf
 from shaman.models import Build, Project
-from sqlalchemy import desc, Integer
+from sqlalchemy import desc
 
 
 BUILD_LIMIT = getattr(conf, "build_limit", 1000)

--- a/shaman/templates/builds.html
+++ b/shaman/templates/builds.html
@@ -112,8 +112,11 @@
                                    <div class="col-xs-10">
                                        <a href="{{ v }}" class="list-group-item">
                                            <i class="fa fa-arrow-circle-right fa-fw"></i>
-                                           {{ v }}
-
+                                           {% if name == 'refs' %}
+                                           {{ v if v else ''|truncate(32, True) }}
+                                           {% else %}
+                                           {{ v if v else ''|truncate(10, True) }}
+                                           {% endif %}
                                        </a>
                                    </div>
                                    <div class="col-xs-2">


### PR DESCRIPTION
There is no need now to display the full size of the sha1 now that 'copy to clipboard' is enabled. This helps keep the format of the buttons avoiding an overflow