### PR TITLE
Skip zero count repos when displaying the chart

### DIFF
--- a/shaman/controllers/root.py
+++ b/shaman/controllers/root.py
@@ -50,6 +50,10 @@ class RootController(object):
                         and_(Repo.modified > lower_range),
                         and_(Repo.modified < upper_range)
                 ).count()
+                # Do not add all the projects that haven't built anything for
+                # the day
+                if int(repository_count) == 0:
+                    continue
                 day_data[str(project.name)] = int(repository_count)
             area_data.append(day_data)
 

--- a/shaman/tests/controllers/test_root.py
+++ b/shaman/tests/controllers/test_root.py
@@ -22,10 +22,22 @@ class TestRootController(object):
         result = session.app.get('/')
         assert result.namespace['latest_builds'] == []
 
-    def test_builds_from_today(self, session):
-        models.Build(project=models.Project(name='ceph'), status="ready")
+    def test_repos_from_today(self, session):
+        models.Repo(
+            project=models.Project(name='ceph'),
+            distro="ubuntu",
+            distro_version="xenial",
+            status="ready")
         models.commit()
         result = session.app.get('/')
         now = datetime.datetime.utcnow()
         today_str = now.strftime('%Y-%m-%d')
+        assert "'ceph': 1" in result.namespace['area_data']
         assert today_str in result.namespace['area_data']
+
+    def test_no_builds_from_today(self, session):
+        # create a build, no repos
+        models.Build(project=models.Project(name='ceph'), status="ready")
+        models.commit()
+        result = session.app.get('/')
+        assert "'ceph': 0" not in result.namespace['area_data']


### PR DESCRIPTION
This is to avoid the problem of including every single project in the chart overview when there aren't any repos built for that day.

![screen shot 2018-05-08 at 7 59 08 am](https://user-images.githubusercontent.com/317847/39756007-dc8c6d2a-5295-11e8-9b47-fe3e9299c16a.png)
