### PR TITLE
Keep old builds from being used when jenkins is redeployed

### DIFF
--- a/shaman/controllers/api/builds/projects.py
+++ b/shaman/controllers/api/builds/projects.py
@@ -46,7 +46,7 @@ class ProjectAPIController(object):
         if queued_build:
             build = queued_build
         else:
-            build = models.Build.query.filter_by(url=url).first()
+            build = models.Build.query.filter_by(url=url, sha1=request.json['sha1']).first()
         data = dict(
             project=self.project,
             ref=request.json["ref"],

--- a/shaman/tests/controllers/test_builds.py
+++ b/shaman/tests/controllers/test_builds.py
@@ -96,7 +96,17 @@ class TestApiProjectController(object):
         assert result.status_int == 200
         build = Build.get(1)
         assert build.status == "completed"
-        assert build.completed
+
+    def test_update_build_same_url_different_sha1(self, session):
+        # this tests the situation where a new jenkins instance
+        # is spun up at the same URL and the jenkins urls are
+        # now duplicating
+        session.app.post_json('/api/builds/ceph/', params=self.data)
+        data = self.data.copy()
+        data['sha1'] = "new-sha1"
+        result = session.app.post_json('/api/builds/ceph/', params=data)
+        assert result.status_int == 200
+        assert len(Build.query.all()) == 2
 
     def test_update_queued_build_creates_single_object(self, session):
         data = get_build_data(status='queued', url='jenkins.ceph.com/trigger')


### PR DESCRIPTION
The jenkins server was rebuilt and brought back up at the
same url which caused old build records to be used. This
keeps that from happening by querying for builds by
both url and sha1.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>