### PR TITLE
api/builds: Send email when build is completed

### DIFF
--- a/config/dev.py
+++ b/config/dev.py
@@ -86,6 +86,9 @@ health_check_retries = 3
 # if this file exists the check at /_health/ will fail
 fail_check_trigger_path = "/tmp/fail_check"
 
+# Email ID used to notify build completion
+result_email = "ceph-qa@ceph.com"
+
 RABBIT_HOST = "localhost"
 RABBIT_USER = "guest"
 RABBIT_PW = "guest"

--- a/shaman/controllers/api/builds/projects.py
+++ b/shaman/controllers/api/builds/projects.py
@@ -1,7 +1,11 @@
 import datetime
+import smtplib, socket
+from email.mime.text import MIMEText
+import requests
 
 from pecan import expose, abort, request
 from pecan.secure import secure
+from pecan import conf
 
 from shaman.models import Project, Build
 from shaman.auth import basic_auth
@@ -63,11 +67,42 @@ class ProjectAPIController(object):
         )
         if request.json["status"] == "completed":
             data["completed"] = datetime.datetime.utcnow()
+            self._send_build_completion_email(data)
         if not build:
             build = models.get_or_create(Build, **data)
         else:
             build.update_from_json(data)
         return {}
+
+    def _send_build_completion_email(self, data):
+        result_sender = getattr(conf, "result_email", "")
+        result_receiver = self._get_receiver_email(sha1=data["sha1"])
+        if not result_receiver:
+            print("Mail not sent! Cannot find commit in ceph/ceph-ci.")
+            return
+        subject = "Shaman build completed for {project} ({ref}) for {distro}".format(
+                project=data['project'].name, ref=data['ref'], distro=data['distro'], flavor=data['flavor'])
+    
+        msg = MIMEText("Build completed for: \n\n {status} | {project} | {ref} | {distro} | {distro_version} | \
+                {flavor} | {distro_arch}".format(status=data["status"], project=data['project'].name, ref=data['ref'], \
+                distro=data['distro'], distro_version=data["distro_version"], flavor=data['flavor'], distro_arch=data["distro_arch"]))
+        msg['Subject'] = subject
+        msg['From'] = result_sender
+        msg['To'] = result_receiver
+        try:
+            smtp = smtplib.SMTP('localhost', 1025)
+            smtp.sendmail(msg['From'], [msg['To']], msg.as_string())
+            smtp.quit()
+        except socket.error:
+            print("Failed to connect to mail server!")
+
+    def _get_receiver_email(self, sha1):
+        url = "https://api.github.com/repos/ceph/ceph-ci/git/commits/{commit_hash}".format(commit_hash=sha1)
+        try:
+            data = requests.get(url).json()
+            return data["author"]["email"]
+        except:
+            return ""
 
     @expose()
     def _lookup(self, ref_name, *remainder):


### PR DESCRIPTION
[WIP] TODO: Add information (in the emails) about necessary builds required for scheduling.

Receive emails for testing with `python -m smtpd -c DebuggingServer -n localhost:1025`

Signed-off-by: Vallari Agrawal <val.agl002@gmail.com>