### PR TITLE
Fix python3 deps error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ requests
 jinja2
 pika
 enum34
+cherrypy>=3.8.0,<9.0.0


### PR DESCRIPTION
Fix dep error when run `pecan serve config/run.py`: 

```bash
(virtualenv) [shaman@142ba6b2f6af shaman]$ pecan serve config/run.py
Traceback (most recent call last):
  File "/home/shaman/virtualenv/bin/pecan", line 33, in <module>
    sys.exit(load_entry_point('pecan', 'console_scripts', 'pecan')())
  File "/home/shaman/virtualenv/lib/python3.6/site-packages/pecan/commands/base.py", line 96, in handle_command_line
    runner.run(sys.argv[1:])
  File "/home/shaman/virtualenv/lib/python3.6/site-packages/pecan/commands/base.py", line 91, in run
    self.commands[ns.command_name]().run(ns)
  File "/home/shaman/virtualenv/lib/python3.6/site-packages/pecan/commands/serve.py", line 38, in run
    app = self.load_app()
  File "/home/shaman/virtualenv/lib/python3.6/site-packages/pecan/commands/base.py", line 162, in load_app
    return load_app(self.args.config_file)
  File "/home/shaman/virtualenv/lib/python3.6/site-packages/pecan/core.py", line 213, in load_app
    set_config(config, overwrite=True)
  File "/home/shaman/virtualenv/lib/python3.6/site-packages/pecan/configuration.py", line 252, in set_config
    config = conf_from_file(config)
  File "/home/shaman/virtualenv/lib/python3.6/site-packages/pecan/configuration.py", line 178, in conf_from_file
    SourceFileLoader(module_name, abspath).load_module(module_name)
  File "<frozen importlib._bootstrap_external>", line 399, in _check_name_wrapper
  File "<frozen importlib._bootstrap_external>", line 823, in load_module
  File "<frozen importlib._bootstrap_external>", line 682, in load_module
  File "<frozen importlib._bootstrap>", line 265, in _load_module_shim
  File "<frozen importlib._bootstrap>", line 684, in _load
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/shaman/shaman/config/run.py", line 3, in <module>
    import cherrypy
ModuleNotFoundError: No module named 'cherrypy'
```

