### PR TITLE
Make prod.py's imports work in py3

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -1,4 +1,11 @@
 # {{ ansible_managed }}
+# the imports of prod_db and prod_api_creds worked in py2
+# because "relative to the current file" imports were
+# permitted.  In py3 they are not, so add the path of
+# the current file (prod.py) to sys.path here
+
+import sys, os
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 from pecan.hooks import TransactionHook, RequestViewerHook
 from shaman import models
 from prod_db import sqlalchemy_w, sqlalchemy_ro


### PR DESCRIPTION
prod.py imports prod_db.py and prod_api_creds.py.  In py2 it could do this just by being in the same directory.  In py3, that's not good enough, and 'from .' only works from an "enclosing package", which apparently this is not (it's not in the shaman source directory or in the venv directory for all the other packages).

Append to sys.path to make the imports work.